### PR TITLE
Adding #include to the example

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ To use the library you will need:
 Here's a quick example of how to use the library to send 3 values:
 
 ``` cpp
-# "Ubidots.h"
+#include "Ubidots.h"
 
 Ubidots ubidots("CCN8FrVulGRBulATkbaiR9Myx8qN2o"); // change this with your token
 


### PR DESCRIPTION
#include "Ubidots.h" was not present in the example