### PR TITLE
Update UbidotsSendValuesWithTimeStamp.cpp

### DIFF
--- a/examples/UbidotsSendValuesWithTimeStamp/UbidotsSendValuesWithTimeStamp.cpp
+++ b/examples/UbidotsSendValuesWithTimeStamp/UbidotsSendValuesWithTimeStamp.cpp
@@ -33,18 +33,18 @@ void setup() {
 
 void loop() {
   float value1 = analogRead(A0);
-  unsigned long t = ubidots.ntpUnixTime(); // calculates your actual timestamp in SECONDS
+  unsigned long t = Time.now(); // calculates your actual timestamp in SECONDS
 
-  ubidots.add("test-1", value1);  // Change the first argumento for your var's label
-  ubidots.add("test-2", value1, NULL, t-20000);  // Sends a value with a custom timestamp
-  ubidots.add("test-3", value1);
+  ubidots.add("test-1", value1);  // Change the first argument for your var's label
+  ubidots.add("test-2", value1, NULL, t-3600);  // Set custom timestamp, -3600 seconds (1hr)
+  ubidots.add("test-3", value1);  // Default timestamp applied at SEND time
 
   bool bufferSent = false;
+  
   if(ubidots.isDirty()){  // There are stored values in buffer
-
-    // Sends variables 'test-1' and 'test-2' with your actual timestamp,
-    // variable 'test-2' will be send with its custom timestamp
-    bufferSent = ubidots.sendAll();
+    // Variables 'test-1' and 'test-3' will be sent with time-sent timestamp
+    // Variable 'test-2' will be sent with previously applied custom timestamp
+    bufferSent = ubidots.sendAll(); 
   }
 
   if(bufferSent){


### PR DESCRIPTION
My first pull request. Changed from ubidots.ntpUnixTime() to Time.now() to get time in seconds (thank you Jose!). Changed timestamp offset to -3600 (1hr) to emphasise the offset is in seconds. 

Fixed a typo in the .isDirty() case ('test-1' and 'test-2' should have been 'test-1' and 'test-3'. Added comment // Default timestamps applied at SEND time. 

Tweaked the verbage to be more clear that data points without a custom timestamp received a timestamp when transmitted. Ubidots rocks!