### PR TITLE
UbiHTTP

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Ubidots
-version=3.2.2
+version=3.2.3
 license=MIT
 author=Ubidots <devel@ubidots.com>, Jose Garcia <jose.garcia@ubidots.com>
 maintainer=Jose García <jose.garcia@ubidots.com>

--- a/src/UbiHttp.cpp
+++ b/src/UbiHttp.cpp
@@ -134,7 +134,7 @@ float UbiHTTP::get(const char* device_label, const char* variable_label) {
     _client_http_ubi.print("/lv");
     _client_http_ubi.print(" HTTP/1.1\r\n");
     _client_http_ubi.print("Host: ");
-    _client_http_ubi.print(UBIDOTS_HTTP_PORT);
+    _client_http_ubi.print(_host);
     _client_http_ubi.print("\r\n");
     _client_http_ubi.print("User-Agent: ");
     _client_http_ubi.print(_user_agent);
@@ -152,7 +152,7 @@ float UbiHTTP::get(const char* device_label, const char* variable_label) {
       Serial.print("/lv");
       Serial.print(" HTTP/1.1\r\n");
       Serial.print("Host: ");
-      Serial.print(UBIDOTS_HTTP_PORT);
+      Serial.print(_host);
       Serial.print("\r\n");
       Serial.print("User-Agent: ");
       Serial.print(_user_agent);


### PR DESCRIPTION
Fixing issue with wrong host parameter at get() method from HTTP class. It should be _host and
not the global HTTP port